### PR TITLE
Fixed tweets not fetching >7 days

### DIFF
--- a/community_pulse/twitter.py
+++ b/community_pulse/twitter.py
@@ -38,7 +38,7 @@ def get_data(querystring, translate: bool, ignore: list):
                             expansions=['author_id', 'referenced_tweets.id'],
                             user_fields=['username'],
                             max_results=50,
-                            since_id=None)
+                            since_id=most_recent_tweet_id)
   # reverse=True)
 
   for tweet_page in tweets_iterator(tweets):

--- a/community_pulse/twitter.py
+++ b/community_pulse/twitter.py
@@ -153,24 +153,25 @@ def full_lang(tweet_lang: str) -> str:
 def get_marker():
   """Get the last indexed tweet ID"""
   os_client = get_os_client()
-  """             "range": {
-            "created_at": {
-                "gte": "now-7d/d",
-                "lt": "now/d"
-            }
-        }, """
   query = {
-      "fields": ["_id"],
-      "sort": [{
-          "created_at": {
-              "order": "desc"
-          }
-      },
-          {
-              "_score": {
-                  "order": "desc"
+      "query": {
+        "bool": {
+          "filter": [
+            {
+              "range": {
+                "created_at": {
+                  "gte": "now-7d/d",
+                  "lt": "now/d"
+                }
               }
-      }
+            }
+          ]
+        }
+      },
+      "fields": ["_id"],
+      "sort": [
+        {"created_at": {"order": "desc"}},
+        {"_score": {"order": "desc"}}
       ],
       "size": 1
   }


### PR DESCRIPTION
Getting tweet's "since_id" only works if last tweet occurred within the last seven days. This added functionality to only search for the most recent tweet if it was within the last 7 days, otherwise none is passed to since_id and twitter will simply return the most recent 7 days. 